### PR TITLE
Upgrading docker base image and spark

### DIFF
--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04 as base
+FROM ubuntu:22.04 as base
 
 LABEL maintainer="Lucas Miguel Ponce <lucasmsp@dcc.ufmg.br>"
 
@@ -29,8 +29,8 @@ RUN apt update && apt install -y \
   && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \
   && rm -rf /var/lib/apt/lists/*
 
-ENV SPARK_VERSION=2.4
-ENV HADOOP_VERSION=2.7
+ENV SPARK_VERSION=3.2
+ENV HADOOP_VERSION=3.2
 ENV SPARK_BASE_URL=http://www.apache.org/dist/spark
 
 # Get latest spark based on major.minor version


### PR DESCRIPTION
Upgrading Docker Base image for spark from 21.04 to 22.04 LTS. 
Upgrading the Spark and Hadoop version from 2.4 & 2.7 to 3.2 & 3.2 respectively.

The Non-LTS release support termination lead to repositories to be not found. Upgrading to a LTS release will provide us an extended support for the necessary repositories.
https://serverfault.com/questions/1108176/ubuntu-server-21-04-update-error-on-apt-update
https://unix.stackexchange.com/questions/715846/trying-to-do-an-update-and-im-getting-these-errors-im-running-ubuntu-21-04